### PR TITLE
make adios4dolfinx noarch

### DIFF
--- a/recipes/adios4dolfinx/meta.yaml
+++ b/recipes/adios4dolfinx/meta.yaml
@@ -7,15 +7,12 @@ package:
   version: {{ version }}
 
 source:
-  # url: https://github.com/jorgensd/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  # sha256: 5e1ba02f2cdebe22193d6134684e4b733e500f07146e1a84cb8aaa329098dbba
-  git_url: https://github.com/jorgensd/adios4dolfinx.git
-  git_rev: dokken/debug_conda
+  url: https://github.com/jorgensd/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 5e1ba02f2cdebe22193d6134684e4b733e500f07146e1a84cb8aaa329098dbba
 
 build:
   number: 0
-  skip: true  # [win]
-  skip: true  # [osx and mpi == 'openmpi']
+  noarch: python
 
   # openmpi oversubscribe env
   script_env:
@@ -30,23 +27,19 @@ build:
   script: python -m pip install . -vv
 
 requirements:
-  build:
-    - pkg-config
-    - python  # [build_platform != target_platform]
+  host:
+    - python >=3.9
     - pip
   run:
     - fenics-dolfinx {{ major_minor }}
-    - adios2 * mpi_{{ mpi }}_*
-    - {{ mpi }}
+    - adios2 * mpi_*
     - numpy >=1.21
-    - python
+    - python >=3.9
     - mpi4py
 
-# test:
-#   imports:
-#     - adios4dolfinx
 test:
   source_files:
+    - pyproject.toml
     - tests
   requires:
     - pip


### PR DESCRIPTION
only one build needed

adds pyproject.toml to test files for pytest config, which appears to fix tests without needing a patch or new release